### PR TITLE
tag add Outbrain/VisualRevenue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist
 ._*
 .Spotlight-V100
 .Trashes
+.idea/
 ehthumbs.db
 Thumbs.db
 .git

--- a/libraries/outbrain/vendor.json
+++ b/libraries/outbrain/vendor.json
@@ -1,0 +1,6 @@
+{
+  "id": 1477478424928256,
+  "name": "outbrain",
+  "imageUrl": "http://www.outbrain.com/images/lp/templates/template-1/logo.png",
+  "description": "Outbrain is a content discovery platform that allows you to get your content onto thousands of premium publisher sites around the web."
+}

--- a/libraries/outbrain/visualrevenue/v1/Tag.js
+++ b/libraries/outbrain/visualrevenue/v1/Tag.js
@@ -1,0 +1,39 @@
+//:include tagsdk-current.js
+
+qubit.opentag.LibraryTag.define("outbrain.visualrevenue.v1.Tag", {
+	config: {
+		/*DATA*/
+		name: "visualrevenue",
+		async: true,
+		description: "Visual Revenue (Outbrain) permit to get in real time the most visited articles, and optimize the audience performances.",
+		html: "",
+		locationDetail: "",
+		isPrivate: false,
+		url: "http://a.visualrevenue.com/vrs.js",
+		usesDocWrite: false,
+		upgradeable: true,
+		parameters: [{
+			name:"Visual Revenue id",
+			description:"Visual Revenue id",
+			token:"visualrevenue_id",
+			uv:"universal_variable.outbrain.visualrevenue_id"
+		}]
+		/*~DATA*/
+	},
+	script: function() {
+	/*SCRIPT*/
+	/*~SCRIPT*/
+	},
+	pre: function() {
+		/*PRE*/
+		var _vrq = _vrq || [];
+		_vrq.push(['id', this.valueForToken("visualrevenue_id")]);
+		_vrq.push(['automate', true]);
+		_vrq.push(['track', function(){}]);
+		/*~PRE*/
+	},
+	post: function() {
+	/*POST*/
+	/*~POST*/
+	}
+});


### PR DESCRIPTION
original script:

    var _vrq = _vrq || [];
    _vrq.push(['id', 000]);
    _vrq.push(['automate', true]);
    _vrq.push(['track', function(){}]);
    (function(d, a){
        var s = d.createElement(a),
            x = d.getElementsByTagName(a)[0];
        s.async = true;
        s.src = 'http://a.visualrevenue.com/vrs.js';
        x.parentNode.insertBefore(s, x);
    })(document, 'script');

http://www.outbrain.com/blog/2013/03/outbrain-acquires-visual-revenue-inc.html


> **do you manage** dns-prefetch ?

It would be nice to add all concerned domains in a prefetch or domain array, ex this script calls known domains (a.visualrevenue.com p.visualrevenue.com t1.visualrevenue.com) that could be prefetched (optional) : 

< link rel="dns-prefetch" href="http://a.visualrevenue.com">< link rel="dns-prefetch" href="http://p.visualrevenue.com">< link rel="dns-prefetch" href="http://t1.visualrevenue.com">