### PR TITLE
amazon direct match buying setup

### DIFF
--- a/libraries/amazon/amazondirectmatchbuying/v1/Tag.js
+++ b/libraries/amazon/amazondirectmatchbuying/v1/Tag.js
@@ -1,0 +1,40 @@
+//:include tagsdk-current.js
+
+qubit.opentag.LibraryTag.define("amazon.amazondirectmatchbuying.v1.Tag", {
+	config: {
+		/*DATA*/
+		name: "amazondirectmatchbuying",
+		async: false,
+		description: "The Amazon Direct Match Buying program is designed to integrate Amazon’s demand into your ad server and ad optimization stack. It works through two main components, an Amazon-provided JavaScript and the Key-Value targeting or Custom Targeting feature in your ad server. Use amznads.getTokens() to send the tokens to your ad server. Debug mode to get test tokens : //url?amzn_debug_mode=1 .",
+		html: "",
+		locationDetail: "",
+		isPrivate: false,
+		url: "//c.amazon-adsystem.com/aax2/amzn_ads.js",
+		usesDocWrite: false,
+		upgradeable: true,
+		parameters: [
+			{
+				name: "Amazon direct match buying id",
+				description: "Amazon direct match buying id",
+				token: "amazon_direct_match_buying_id",
+				uv: "universal_variable.amazon.amazon_direct_match_buying_id"
+			}
+		]
+		/*~DATA*/
+	},
+	script: function() {
+	/*SCRIPT*/
+	/*~SCRIPT*/
+	},
+	pre: function() {
+	/*PRE*/
+	/*~PRE*/
+	},
+	post: function() {
+	/*POST*/
+		try {
+			amznads.getAds(this.valueForToken("amazon_direct_match_buying_id"));
+		} catch(e) { /*ignore*/}
+	/*~POST*/
+	}
+});

--- a/libraries/amazon/vendor.json
+++ b/libraries/amazon/vendor.json
@@ -1,0 +1,6 @@
+{
+"id": 1479508935331840,
+"name": "amazon",
+"imageUrl": "https://images-na.ssl-images-amazon.com/images/G/01/AdProductsWebsite/images/amazon-ads-logo.png",
+"description": "Amazon advertising solutions"
+}


### PR DESCRIPTION
The Amazon Direct Match Buying program is designed to integrate Amazon’s demand into your ad server and ad optimization stack. It works through two main components, an Amazon-provided JavaScript and the Key-Value targeting or Custom Targeting feature in your ad server. The JavaScript needs to be included in the header of your web pages. It calls Amazon to see if we have ads available to show on the page and sets a flag or a key for each ad that Amazon has available.  You also need to set up ad tags provided by Amazon in your ad server. When serving an ad, you ad server includes the Amazon tag ad as a candidate in its consideration set if the key value pair is set. It only serves the Amazon ad tag if it meets all of its own optimization criteria and if the key value pair is set.

https://advertising.amazon.com/