### PR TITLE
change variable names

### DIFF
--- a/libraries/veinteractive/confirmationpixel/v1/Tag.js
+++ b/libraries/veinteractive/confirmationpixel/v1/Tag.js
@@ -7,7 +7,7 @@ qubit.opentag.LibraryTag.define("veinteractive.confirmationpixel.v1.Tag", {
 		name: "Confirmation Pixel",
 		async: true,
 		description: "Tag to be added only to the confirmation page",
-		html: "<img src=\"${id}\" width=\"1\" height=\"1\"/>",
+		html: "<img src=\"${ID}\" width=\"1\" height=\"1\"/>",
 		locationDetail: "",
 		isPrivate: false,
 		url: "",
@@ -16,7 +16,7 @@ qubit.opentag.LibraryTag.define("veinteractive.confirmationpixel.v1.Tag", {
 		parameters: [{
 			name: "VE Interactive Pixel",
 			description: "The ID for the tag in this format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX with dashes included",
-			token: "id",
+			token: "ID",
 			uv: ""
 		}],
 		categories:[

--- a/libraries/veinteractive/containertag/v1/Tag.js
+++ b/libraries/veinteractive/containertag/v1/Tag.js
@@ -16,7 +16,7 @@ qubit.opentag.LibraryTag.define("veinteractive.containertag.v1.Tag", {
 		parameters: [{
 			name: "VE Interactive tag",
 			description: "The ID for the tag in this format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX with dashes included",
-			token: "id",
+			token: "ID",
 			uv: ""
 		}],
 		categories:[
@@ -28,7 +28,7 @@ qubit.opentag.LibraryTag.define("veinteractive.containertag.v1.Tag", {
   },
 	script: function() {
 		/*script*/
-		var scriptURL = this.valueForToken("id");
+		var scriptURL = this.valueForToken("ID");
 		var script = document.createElement("script");
 
 		script.src = scriptURL;


### PR DESCRIPTION
With the latest change on Qubit Opentag, our integration did not work anymore.

After research, we realised that the problem was with the names of the parameter, which needed to be "ID" instead of "id". With this change, we managed to make the integration work.

Thank you,
VeInteractive team