### PR TITLE
Add a new tag for 'uplift'

### DIFF
--- a/libraries/uplift/Config.js
+++ b/libraries/uplift/Config.js
@@ -1,0 +1,10 @@
+var Config = {
+/*config*/
+	"id": 1504410149140480,
+	"name": "uplift",
+	"imageUrl": "http://cdn.uplift-platform.com/a/uplift_logo_trans.png",
+	"description": "UpLift is a payment marketing platform that helps building deeper, more meaningful, longer lasting relationships with consumers through payment analytics and consumer behavior influence."
+/*~config*/
+};
+
+qubit.Define.vendorNamespace("uplift.Config", Config);

--- a/libraries/uplift/platform/v1/Tag.js
+++ b/libraries/uplift/platform/v1/Tag.js
@@ -1,0 +1,45 @@
+//:include tagsdk-current.js
+
+qubit.opentag.LibraryTag.define("uplift.platform.v1.Tag", {
+	getDefaultConfig: function () {
+		return {
+			/*config*/
+		name: "UpLift Platform Tag",
+		async: true,
+		description: "UpLift Platform Tag provides analytics tooling to help understand customer payment behaviors and to empower merchants to grow consumer loyalty, generate new marketing dollars, and increase conversion.",
+		html: "",
+		locationDetail: "",
+		isPrivate: false,
+		url: "",
+		usesDocWrite: false,
+		upgradeable: true,
+		parameters: [
+			{
+				name: "Account-ID",
+				description: "The Account ID (e.g. UP-12345678-1) is a unique, partner specific identifier. It is provided to you by UpLift Inc. during the on-boarding with UpLift platform.",
+				token: "partner_account_id",
+				uv: ""
+			}, {
+				name: "Partner-Domain",
+				description: "Partner domain (e.g. example.com) is the root domain for the partner's website hosting the pages with the tag.",
+				token: "partner_domain",
+				uv: ""
+			}
+		]
+			/*~config*/
+		};
+	},
+	script: function() {
+	/*script*/
+		(function(u,p,l,i,f,t,o,b,j){u['UpLiftPlatformObject']=f;u[f]=u[f]||function(){(u[f].q=u[f].q||[]).push(arguments)},u[f].l=1*new Date();b=p.createElement(l),j=p.getElementsByTagName(l)[0];b.async=1;b.src=i+'?id='+t;j.parentNode.insertBefore(b,j);u[f]('create',t,o)})(window,document,'script','//cdn.uplift-platform.com/a/up.js','up',this.valueForToken('partner_account_id'),this.valueForToken('partner_domain'));up('send','pageview');
+	/*~script*/
+	},
+	pre: function() {
+	/*pre*/
+	/*~pre*/
+	},
+	post: function() {
+	/*post*/
+	/*~post*/
+	}
+});

--- a/libraries/uplift/platform/v1/local/BDDSuite.js
+++ b/libraries/uplift/platform/v1/local/BDDSuite.js
@@ -1,0 +1,36 @@
+/**ignore at merge**/
+//:include tagsdk-current.js
+//:include uplift/platform/v1/Tag.js
+
+/*
+ * BDD tests are well known unit tests supporting API used by mocha and
+ * other test runners. Please see more info about how to use them online.
+ */
+var suite = describe("firing a tag", function() {
+
+  var tag = null;
+
+  beforeEach(function() {
+    tag = new uplift.platform.v1.Tag({
+      name: "Specify a name here"
+    });
+  });
+
+  afterEach(function() {
+
+  });
+
+  it("should fail", function() {
+    expect(true).to.be(false);
+  });
+
+  it("should pass", function() {
+    expect(true).to.be(true);
+  });
+
+  it("should throw an exception", function() {
+    throw "exception!";
+  });
+});
+
+qubit.opentag.Utils.namespace('uplift.platform.v1.local.BDDSuite', suite);


### PR DESCRIPTION
One of your customers and our future partner requested that we add our tag to the Qubit's Open Tag library.

UpLift Platform Tag provides basic tooling to enable our products on partner websites.
It takes two parameters: Account ID and Domain name. Correct values for these parameters are provided to partner organization at the time of on-boarding with the Uplift platform.