### PR TITLE
Replace use of escape with encodeURIComponent

### DIFF
--- a/libraries/mentionme/banner/v1/Tag.js
+++ b/libraries/mentionme/banner/v1/Tag.js
@@ -81,7 +81,7 @@ qubit.opentag.LibraryTag.define("mentionme.banner.v1.Tag", {
 
 		for (var param in paramObj) {
 			var value = paramObj[param];
-			paramArr.push(param + "=" + escape(value));
+			paramArr.push(param + "=" + encodeURIComponent(value));
 		}
 
 		mmScript.src = baseUrl + paramArr.join("&");

--- a/libraries/mentionme/dashboard/v1/Tag.js
+++ b/libraries/mentionme/dashboard/v1/Tag.js
@@ -94,7 +94,7 @@ qubit.opentag.LibraryTag.define("mentionme.dashboard.v1.Tag", {
 
 		for (var param in paramObj) {
 			var value = paramObj[param];
-			paramArr.push(param + "=" + escape(value));
+			paramArr.push(param + "=" + encodeURIComponent(value));
 		}
 
 		mmScript.src = baseUrl + paramArr.join("&");

--- a/libraries/mentionme/refereetag/v1/Tag.js
+++ b/libraries/mentionme/refereetag/v1/Tag.js
@@ -69,7 +69,7 @@ qubit.opentag.LibraryTag.define("mentionme.refereetag.v1.Tag", {
 
 		for (var param in paramObj) {
 			var value = paramObj[param];
-			paramArr.push(param + "=" + escape(value));
+			paramArr.push(param + "=" + encodeURIComponent(value));
 		}
 
 		mmScript.src = baseUrl + paramArr.join("&");

--- a/libraries/mentionme/referrertag/v1/Tag.js
+++ b/libraries/mentionme/referrertag/v1/Tag.js
@@ -162,7 +162,7 @@ qubit.opentag.LibraryTag.define("mentionme.referrertag.v1.Tag", {
 
 		for (var param in paramObj) {
 			var value = paramObj[param];
-			paramArr.push(param + "=" + escape(value));
+			paramArr.push(param + "=" + encodeURIComponent(value));
 		}
 
 		var mmScript = document.createElement("script");


### PR DESCRIPTION
We've incorrectly used escape instead of encodeURIComponent. This switches to the correct version.